### PR TITLE
Add generics to structures

### DIFF
--- a/src/debug_types.rs
+++ b/src/debug_types.rs
@@ -14,6 +14,9 @@ pub enum DebugTypeError {
         owner: String,
         member: String,
     },
+    GenericNotFound {
+        owner: String,
+    },
     StructureNotFound {
         owner: String,
     },
@@ -73,6 +76,9 @@ impl core::fmt::Display for DebugTypeError {
             }
             DebugTypeError::MemberNotFound { owner, member } => {
                 write!(f, "Member \"{}\" not found in struct \"{}\"", member, owner)
+            }
+            DebugTypeError::GenericNotFound { owner } => {
+                write!(f, "Generic not found in struct \"{}\"", owner)
             }
             DebugTypeError::VariableNotFound(v) => {
                 write!(f, "Variable \"{}\" could not be found", v)
@@ -900,12 +906,19 @@ impl<'a> DebugPointer<'a> {
         let location = self.location?.0 + offset;
         memory_source.read_u8(location).ok()
     }
+
+    pub fn location(&self) -> Result<u64, DebugTypeError> {
+        self.location
+            .ok_or(DebugTypeError::LocationMissing)
+            .map(|location| location.0)
+    }
 }
 
 impl core::fmt::Debug for DebugPointer<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DebugPointer")
             .field("pointer", &self.pointer)
+            .field("location", &self.location)
             .finish()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ use std::path::Path;
 use std::rc::Rc;
 
 use debug_types::{DebugTypeError, DebugVariable};
-use unit_info::UnitInfo;
+use unit_info::{UnitInfo, Variable};
 
 use crate::debug_types::{DebugEnumeration, DebugStructure, DebugUnion};
 
@@ -223,6 +223,19 @@ impl DebugInfo {
             }
         }
         Err(DebugTypeError::VariableNotFound(path.into()))
+    }
+
+    pub fn find_variable<P>(&self, predicate: P) -> Result<DebugVariable, DebugTypeError>
+    where
+        Self: Sized,
+        P: Fn(&&Variable) -> bool,
+    {
+        for unit in &self.units {
+            if let Some(variable) = unit.find_variable(&predicate) {
+                return Ok(DebugVariable::new(unit, self, variable));
+            }
+        }
+        Err(DebugTypeError::VariableNotFound("".into()))
     }
 
     /// Consult all units to look for a structure with the specified name. If the structure

--- a/src/unit_info.rs
+++ b/src/unit_info.rs
@@ -30,7 +30,7 @@ impl DebugItem {
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 /// A location within the running target
-pub struct MemoryLocation(pub(crate) u64);
+pub struct MemoryLocation(pub u64);
 
 impl core::fmt::Display for MemoryLocation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -874,6 +874,14 @@ impl UnitInfo {
             .variable_address
             .get(&location)
             .and_then(|addr| self.cache.variables.get(addr.0))
+    }
+
+    pub fn find_variable<P>(&self, predicate: P) -> Option<&Variable>
+    where
+        Self: Sized,
+        P: Fn(&&Variable) -> bool,
+    {
+        self.cache.variables.iter().find(predicate)
     }
 
     pub fn structure_from_item(&self, location: DebugItem) -> Option<&Structure> {


### PR DESCRIPTION
This adds generics (template types) information to structures.

This also adds the ability to instantiate a DebugStructure at a given address with a particular DebugItem.