### PR TITLE
DebugStructure holds onto its own kind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tasru"
-version = "0.3.11"
+version = "0.3.12"
 edition = "2024"
 description = "A method to map and understand dwarf symbol information"
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,11 +414,11 @@ impl DebugInfo {
                 continue;
             };
 
-            return Ok(DebugBaseType {
-                location: Some(MemoryLocation(address)),
-                offset: StructOffset(0),
+            return Ok(DebugBaseType::new(
+                Some(MemoryLocation(address)),
+                StructOffset(0),
                 base_type,
-            });
+            ));
         }
 
         Err(DebugTypeError::BaseTypeNotFound {


### PR DESCRIPTION
DebugStructure needs to in case we need to translate a DebugStructure back into a DWARF offset

We also remove some extra `pub` annotations that are no longer necessary.