### PR TITLE
Add ReadWrite trait

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -139,6 +139,15 @@ pub trait Write {
     fn finish(&mut self) {}
 }
 
-pub trait ReadWrite: Read + Write {
-    type Error: core::error::Error;
+pub trait ReadWrite<E>: Read<Error = E> + Write<Error = E>
+where
+    E: core::error::Error,
+{
+}
+
+impl<T, E> ReadWrite<E> for T
+where
+    E: core::error::Error,
+    T: Read<Error = E> + Write<Error = E>,
+{
 }

--- a/src/unit_info.rs
+++ b/src/unit_info.rs
@@ -68,7 +68,7 @@ impl From<MemoryLocation> for u64 {
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 /// An offset from the start of the struct
-pub struct StructOffset(pub(crate) u64);
+pub struct StructOffset(pub u64);
 impl StructOffset {
     pub fn new(offset: u64) -> Self {
         StructOffset(offset)


### PR DESCRIPTION
`ReadWrite` trait is necessary because separate `Read` and `Write` traits cannot be combined in certain cases because of the generic error parameter.