### PR TITLE
add predicate-based structure lookup and base type lookup by name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,6 +311,27 @@ impl DebugInfo {
         })
     }
 
+    /// Consult all units to find a structure whose namespace and name
+    /// satisfy the predicate. Unlike [Self::structure_from_type_at_address],
+    /// this can find structures with empty namespaces (tuples, references),
+    /// and leaves name comparison to the caller.
+    pub fn find_structure_by_name<P>(&self, predicate: P) -> Option<&unit_info::Structure>
+    where
+        P: Fn(&str, &str) -> bool,
+    {
+        self.units
+            .iter()
+            .find_map(|unit| unit.find_structure(|s| predicate(s.namespace(), s.name())))
+    }
+
+    /// Consult all units to find a base type by name, returning its
+    /// [unit_info::DebugItem] so it can be used for casts and reads.
+    pub fn find_base_type_item(&self, name: &str) -> Option<unit_info::DebugItem> {
+        self.units
+            .iter()
+            .find_map(|unit| unit.find_base_type_item(|base_type| base_type.name() == name))
+    }
+
     pub fn structure_from_item_at_address(
         &self,
         target_item: &unit_info::DebugItem,

--- a/src/unit_info.rs
+++ b/src/unit_info.rs
@@ -974,6 +974,32 @@ impl UnitInfo {
         self.cache.variables.iter().find(predicate)
     }
 
+    /// Find the first structure in this unit matching the predicate.
+    pub fn find_structure<P>(&self, predicate: P) -> Option<&Structure>
+    where
+        P: Fn(&Structure) -> bool,
+    {
+        self.cache.structures.iter().find(|s| predicate(s))
+    }
+
+    /// Find the first base type in this unit matching the predicate,
+    /// returning its [DebugItem].
+    pub fn find_base_type_item<P>(&self, predicate: P) -> Option<DebugItem>
+    where
+        P: Fn(&BaseType) -> bool,
+    {
+        self.cache
+            .base_type_address
+            .iter()
+            .find(|(_, index)| {
+                self.cache
+                    .base_types
+                    .get(index.0)
+                    .is_some_and(|base_type| predicate(base_type))
+            })
+            .map(|(item, _)| *item)
+    }
+
     pub fn structure_from_item(&self, location: DebugItem) -> Option<&Structure> {
         self.cache
             .structure_address


### PR DESCRIPTION
`DebugInfo::find_structure_by_name` searches structures by a (namespace, name) predicate, which also reaches types with empty namespaces (tuples, references, slices) that
`structure_from_type_at_address` rejects. `DebugInfo::find_base_type_item` resolves primitive names like `usize` to their `DebugItem` so debuggers can evaluate casts such as `(usize*)ptr`.

Both are used by natvis evaluator for `HashMap` bucket-tuple casts, `Rc/Arc` slice pointer arithmetic, and `LinkedList` traversal.